### PR TITLE
Update continue.yml

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -29,7 +29,7 @@ parameters:
   default-branch:
     description: Default branch of the repository.
     type: string
-    default: master
+    default: main
   wildmatch-version:
     description: Wildmatch package version to install. For available versions, check PyPI - https://pypi.org/project/wildmatch/#description
     type: string


### PR DESCRIPTION
## what

Default branches are now usually `main` instead of `master`.

## why

Because it's better.

## references

#89 