### PR TITLE
fix-default-branch-name: to main

### DIFF
--- a/.circleci/src.yml
+++ b/.circleci/src.yml
@@ -37,4 +37,4 @@ workflows:
             - github
           filters:
             branches:
-              ignore: master
+              ignore: main

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -9,7 +9,7 @@ repository:
   topics: circleci, orb, continuation, CI/CD, continuous integration
 
 branches:
-  - name: master
+  - name: main
     protection:
       required_status_checks:
         strict: true

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Get up-and-running with dynamically continued pipelines in these 4 steps:
 The orb will run a workflow (we'll call it `<module>`) if any of the following conditions are met.
 
 1. If `.circleci/<module>.yml` changes (this is configurable, enabled by default).
-2. If changes have been detected within the `<module>/`'s directory on your branch against the repository's default branch (defaults to `master`). See [below](#filtering-or-ignoring-changed-files) on how to filter out CI runs from specific changed files.
+2. If changes have been detected within the `<module>/`'s directory on your branch against the repository's default branch (defaults to `main`). See [below](#filtering-or-ignoring-changed-files) on how to filter out CI runs from specific changed files.
 3. If, following merge to the default branch, there are changes to `.circleci/<module>.yml` or under `<module>/`, when diffing against the former commit (you must perform a merge commit for this to work properly).
 
 These conditions can be overridden, and all workflows forced to run, if the `force-all` parameter is set to `true` on the `continue` job.
@@ -235,13 +235,6 @@ Append the following to your `.pre-commit-config.yaml` -
 ```
 
 You must have the [`circleci`](https://circleci.com/docs/2.0/local-cli/) CLI installed.
-
-## Live Examples of dynamic-continuation
-
-I use and test this orb in my own projects.
-
-- [`minikube`](https://github.com/bjd2385/minikube/tree/master/.circleci) - this is a simple example with basic configs.
-- [this repo](.circleci/) - that's right, this repo uses it as well!
 
 ## Development
 

--- a/src/commands/filter.yml
+++ b/src/commands/filter.yml
@@ -20,7 +20,7 @@ parameters:
   default-branch:
     description: The default branch of the repository.
     type: string
-    default: master
+    default: main
   wildmatch-version:
     description: Wildmatch package version to install. For available versions, check PyPI - https://pypi.org/project/wildmatch/
     type: string

--- a/src/scripts/filter.sh
+++ b/src/scripts/filter.sh
@@ -104,7 +104,7 @@ $SH_MODULES
 fi
 
 
-# Add each module to `modules-filtered` if 1) `force-all` is set to `true`, or 2) there is a diff against master at HEAD, or 3) no workflow runs have occurred on the default branch for this project in the past $SH_REPORTING_WINDOW days.
+# Add each module to `modules-filtered` if 1) `force-all` is set to `true`, or 2) there is a diff against main at HEAD, or 3) no workflow runs have occurred on the default branch for this project in the past $SH_REPORTING_WINDOW days.
 if [ "$SH_FORCE_ALL" -eq 1 ] || { [ "$SH_REPORTING_WINDOW" != "" ] && [ "$(curl -s -X GET --url "https://circleci.com/api/v2/insights/${SH_PROJECT_TYPE}/${_CIRCLE_ORGANIZATION}/${CIRCLE_PROJECT_REPONAME}/workflows?reporting-window=${SH_REPORTING_WINDOW}" --header "Circle-Token: ${_CIRCLE_TOKEN}" | jq -r "[ .items[].name ] | length")" -eq "0" ]; }; then
     info "running all workflows."
     printf "%s" "$SH_MODULES" | awk NF | while read -r module; do


### PR DESCRIPTION
## what

Fixes default branch name references.

## why

The default branch is now `main` instead of `master`.

## references

#90 #89 