### PR TITLE
Fix module auto detection

### DIFF
--- a/src/scripts/filter.sh
+++ b/src/scripts/filter.sh
@@ -95,7 +95,7 @@ done
 # If auto-detecting is enabled (or modules aren't set), check for configs in .circleci/.
 if [ "$SH_AUTO_DETECT" -eq 1 ] || [ "$SH_MODULES" = "" ]; then
     # We need to determine what the modules are, ignoring SH_MODULES if it is set.
-    SH_MODULES="$(find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -vP "^/?(config)$" | sed "s@${SH_ROOT_CONFIG}@.@")"
+    SH_MODULES="$(find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -vP "^/?(config)$" | sed "s@^${SH_ROOT_CONFIG}\$@.@")"
     info "auto-detected the following modules:
 
 $SH_MODULES


### PR DESCRIPTION
## what

Change root module name mangling `sed` command in `filter.sh` for the auto module detection logic to correctly handle the value of `root-config` in correlation of other module names.

## why

The default value for `root-config` is set to `app` in: https://github.com/emmeowzing/dynamic-continuation-orb/blob/v3.9.0/src/commands/filter.yml#L36-L39

The `sed` command is wrong in the sense that if there are modules with `app` or the vale of `root-config` in their name, then all instances of it will be replaces with a `.`.

This causes such modules to be ignored unless `root-config` is set to something nonsense that is not a substring of any of the module names. 

### example

Imagine the following setup:

```shell
$ ls .circleci | sort
app-deployment-promise.yml
config.yml
github-app-promise.yml
github-template-repo-promise.yml

# As of the current state, the detected modules will be:
$ find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -vP "^/?(config)$" | sed "s@${SH_ROOT_CONFIG}@.@"
github-template-repo-promise
github-.-promise
.-deployment-promise

# After the modification, the detected modules will be
$ find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -vP "^/?(config)$" | sed "s@^${SH_ROOT_CONFIG}\$@.@"
github-template-repo-promise
github-app-promise
app-deployment-promise

# Let's add `app.yml` to make sure it works for the `root-config` case.
$ touch .circleci/app.yml

$ ls .circleci | sort
app-deployment-promise.yml
app.yml
config.yml
github-app-promise.yml
github-template-repo-promise.yml

$ find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -vP "^/?(config)$" | sed "s@^${SH_ROOT_CONFIG}\$@.@"
github-template-repo-promise
github-app-promise
app-deployment-promise
.
```