### PR TITLE
fix: make continue validate step compatible with CircleCI CLI v1.0

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -193,8 +193,12 @@ steps:
       debug: << parameters.debug >>
   - run:
       name: Validate
-      command: |
-        circleci config validate << parameters.continue-config >> --org-slug <<parameters.project-type >>/<< parameters.circle-organization >> --token << parameters.circle-token >>
+      environment:
+        SH_CONTINUE_CONFIG: << parameters.continue-config >>
+        SH_PROJECT_TYPE: << parameters.project-type >>
+        SH_CIRCLE_ORGANIZATION: << parameters.circle-organization >>
+        SH_CIRCLE_TOKEN: << parameters.circle-token >>
+      command: << include(scripts/validate.sh) >>
   - continuation/continue:
       configuration_path: << parameters.continue-config >>
       parameters: << parameters.parameters >>

--- a/src/scripts/validate.sh
+++ b/src/scripts/validate.sh
@@ -1,0 +1,22 @@
+# shellcheck disable=SC2148,SC2153
+
+
+if [ "${SH_CIRCLE_ORGANIZATION:0:1}" = '$' ]; then
+    _CIRCLE_ORGANIZATION="$(eval echo "$SH_CIRCLE_ORGANIZATION")"
+else
+    _CIRCLE_ORGANIZATION="$SH_CIRCLE_ORGANIZATION"
+fi
+
+if [ "${SH_CIRCLE_TOKEN:0:1}" = '$' ]; then
+    _CIRCLE_TOKEN="$(eval echo "$SH_CIRCLE_TOKEN")"
+else
+    _CIRCLE_TOKEN="$SH_CIRCLE_TOKEN"
+fi
+
+ORG_SLUG="${SH_PROJECT_TYPE}/${_CIRCLE_ORGANIZATION}"
+
+if circleci config validate --help 2>&1 | grep -q -- '--org-slug'; then
+    circleci config validate "$SH_CONTINUE_CONFIG" --org-slug "$ORG_SLUG" --token "$_CIRCLE_TOKEN"
+else
+    CIRCLE_TOKEN="$_CIRCLE_TOKEN" circleci config validate "$SH_CONTINUE_CONFIG" --org "$ORG_SLUG"
+fi


### PR DESCRIPTION
## what
  - The continue job's Validate step no longer hard-codes `--org-slug`/`--token`, which CircleCI CLI v1.0 removed from `config validate`.
  - Extracted to `src/scripts/validate.sh` (via include, matching filter.sh/reduce.sh), feature-detecting the CLI: `--org-slug`+`--token` on 0.1.x, `--org`+CIRCLE_TOKEN on 1.0.
  - Backward-compatible.

  ## why
  - CLI v1.0 (stable v1.0.46955, 2026-08-05) is now the default on CircleCI images, so continue fails fleet-wide with `unknown flag: --org-slug`. Private-orb auth is preserved (verified against a private-orb
  config on v1.0.47091).

  ## references
  - Fixes #161